### PR TITLE
Make napari plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+
+.idea

--- a/cellprofiler_library/_function.py
+++ b/cellprofiler_library/_function.py
@@ -1,0 +1,6 @@
+from napari_plugin_engine import napari_hook_implementation
+
+@napari_hook_implementation
+def napari_experimental_provide_dock_widget():
+    from .expandorshrinkobjects import shrink_to_point
+    return [shrink_to_point]

--- a/cellprofiler_library/expandorshrinkobjects.py
+++ b/cellprofiler_library/expandorshrinkobjects.py
@@ -2,7 +2,7 @@ import centrosome.cpmorphology
 import numpy
 import scipy.ndimage
 
-def shrink_to_point(labels, fill):
+def shrink_to_point(labels: "napari.types.LabelsData", fill: bool) -> "napari.types.LabelsData":
     """
     Remove all pixels but one from filled objects.
     If `fill` = False, thin objects with holes to loops.

--- a/cellprofiler_library/napari.yaml
+++ b/cellprofiler_library/napari.yaml
@@ -1,0 +1,11 @@
+name: cellprofiler-library
+display_name: cellprofiler-library
+contributions:
+  commands:
+    - id: cellprofiler_library.shrink_to_point
+      python_name: cellprofiler_library.expandorshrinkobjects:shrink_to_point
+      title: Shrink to point
+  widgets:
+    - command: cellprofiler_library.shrink_to_point
+      autogenerate: true
+      display_name: Shrink to point

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,6 @@ setuptools.setup(
     zip_safe=False,
     entry_points={
         "napari.manifest": ["cellprofiler_library=cellprofiler_library:napari.yaml",],
+        "napari.plugin": ["cellprofiler_library = cellprofiler_library._function",],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,13 @@ setuptools.setup(
     ],
     license="BSD",
     name="cellprofiler-library",
-    package_data={"cellprofiler_library": ["py.typed"]},
+    package_data={"cellprofiler-library": ["py.typed", "napari.yaml"]},
     packages=setuptools.find_packages(exclude=["tests"]),
     python_requires=">=3.8",
     url="https://github.com/CellProfiler/library",
     version="0.0.0",
     zip_safe=False,
+    entry_points={
+        "napari.manifest": ["cellprofiler_library=cellprofiler_library:napari.yaml",],
+    }
 )


### PR DESCRIPTION
Hi Beth @bethac07 ,

this is an attempt to turn this into a napari-plugin. Just an experiment, no need to merge or do anything with it. Happy to close the PR. But I'm curious about the following:

I'm having some issues with testing it, It appears the `centrosome`-library needs an older numpy version then specified in setup.py. I've tried numpy 1.21.5, 1.20.1, 1.19.2 and didn't have luck.
Could you please check in your environment, which numpy version it uses? That's the error I get, when this napari-plugin tries to initialize:

```
===================== Errors for plugin 'cellprofiler_library' =====================

napari version: 0.4.14


ERROR #1: Error in plugin 'cellprofiler_library', hook 'napari_experimental_provide_dock_widget': numpy.ndarray size changed, may indicate binary incompatibility. Expected 96 from C header, got 80 from PyObject 

---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
    [... skipping hidden 1 frame]

~\miniconda3\envs\bio_39\lib\site-packages\napari_plugin_engine\implementation.py in __call__(self=, *args=())
     65     def __call__(self, *args):
---> 66         return self.function(*args)
        self.function = 
        args = ()
     67 

c:\structure\code\cellprofiler_library\cellprofiler_library\_function.py in napari_experimental_provide_dock_widget()
      4 def napari_experimental_provide_dock_widget():
----> 5     from .expandorshrinkobjects import shrink_to_point
        global expandorshrinkobjects = undefined
        shrink_to_point = undefined
      6     return [shrink_to_point]

c:\structure\code\cellprofiler_library\cellprofiler_library\expandorshrinkobjects.py in 
----> 1 import centrosome.cpmorphology
        global centrosome.cpmorphology = undefined
      2 import numpy
      3 import scipy.ndimage

~\miniconda3\envs\bio_39\lib\site-packages\centrosome\cpmorphology.py in 
     11 from .index import Indexes
---> 12 from ._cpmorphology2 import skeletonize_loop, table_lookup_index
        global _cpmorphology2 = undefined
        global skeletonize_loop = undefined
        global table_lookup_index = undefined
     13 from ._cpmorphology2 import grey_reconstruction_loop

centrosome\_cpmorphology2.pyx in init centrosome._cpmorphology2()

ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 96 from C header, got 80 from PyObject

The above exception was the direct cause of the following exception:

PluginCallError                           Traceback (most recent call last)
PluginCallError: Error in plugin 'cellprofiler_library', hook 'napari_experimental_provide_dock_widget': numpy.ndarray size changed, may indicate binary incompatibility. Expected 96 from C header, got 80 from PyObject
================================================================================
```

Thanks!